### PR TITLE
fix(ruff): disable erroneous lints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,5 +54,7 @@ ignore = [
     "FIX",
     "ANN101",
     "ANN102",
+    "COM812",
+    "ISC001"
 ]
 extend-select = ["I"]


### PR DESCRIPTION
Ruff seems to note like them, so we're gonna go ahead and turn 'em off.
